### PR TITLE
Fixed zero velocity swipe

### DIFF
--- a/plugins/fastclick/fastclick.js
+++ b/plugins/fastclick/fastclick.js
@@ -6,6 +6,7 @@ RAD.plugin("plugin.fastclick", function (core) {
         var swiper = this,
             lastMove,
             TOUCH_DIFFERENCE = 20,
+            TOUCHMOVE_DELTA = 1,
             preLastMove;
 
         function extractCoord(e) {
@@ -91,8 +92,12 @@ RAD.plugin("plugin.fastclick", function (core) {
         }
 
         function saveLastPoint(e) {
-            var coords = extractCoord(e);
-            lastMove = preLastMove;
+            var coords = extractCoord(e),
+                dX = Math.abs(coords.screenX - preLastMove.screenX),
+                dY = Math.abs(coords.screenY - preLastMove.screenY);
+            if (dX >= TOUCHMOVE_DELTA || dY >= TOUCHMOVE_DELTA) {
+                lastMove = preLastMove;
+            }
             preLastMove = {
                 screenX: coords.screenX,
                 screenY: coords.screenY,


### PR DESCRIPTION
First met this issue on the **Xperia M** device (Android 4.1.2). Sometimes _'swipe'_ event didn't occur. This happens because Xperia M is dispatched _'touchmove'_ event so fast that on the slightest moving of finger 3 _'touchmove's_ occurs with the same coordinates.
So, I think we should store the **lastMove** coordinates only when the last _'touchmove'_ coordinates has at least **1px** delta from the **preLastMove** coordinates.
